### PR TITLE
[Feat] Button Atom 생성

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,19 @@
         "groups": ["builtin", "external", "internal", "index"],
         "pathGroups": [
           {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "@constants",
+            "group": "internal"
+          },
+          {
+            "pattern": "@storybook/**",
+            "group": "external"
+          },
+          {
             "pattern": "@*/**",
             "group": "internal"
           },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,7 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/preset-create-react-app',
+    '@storybook/addon-controls',
   ],
   framework: '@storybook/react',
   core: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.16.7",
         "@storybook/addon-actions": "^6.4.22",
+        "@storybook/addon-controls": "^6.4.22",
         "@storybook/addon-essentials": "^6.4.22",
         "@storybook/addon-interactions": "^6.4.22",
         "@storybook/addon-links": "^6.4.22",
@@ -38,6 +39,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.0.0",
         "prettier": "^2.6.2",
+        "prop-types": "^15.8.1",
         "webpack": "^5.72.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.16.7",
     "@storybook/addon-actions": "^6.4.22",
+    "@storybook/addon-controls": "^6.4.22",
     "@storybook/addon-essentials": "^6.4.22",
     "@storybook/addon-interactions": "^6.4.22",
     "@storybook/addon-links": "^6.4.22",
@@ -81,6 +82,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.6.2",
+    "prop-types": "^15.8.1",
     "webpack": "^5.72.1"
   }
 }

--- a/src/assets/styles/GlobalStyle.jsx
+++ b/src/assets/styles/GlobalStyle.jsx
@@ -1,5 +1,6 @@
-import { COLOR } from '@constants';
 import { createGlobalStyle } from 'styled-components';
+
+import { COLOR } from '@constants';
 
 const GlobalStyle = createGlobalStyle`
   *,

--- a/src/components/atoms/Button/Button.stories.jsx
+++ b/src/components/atoms/Button/Button.stories.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Button, { ButtonSize, ButtonTheme } from '@components/atoms/Button';
+
+export default {
+  title: 'Atom/Button',
+  component: Button,
+  args: {
+    theme: ButtonTheme.DEFAULT,
+    size: ButtonSize.MEDIUM,
+    onClick: () => {},
+    disabled: false,
+  },
+  argTypes: {
+    theme: {
+      control: {
+        type: 'radio',
+      },
+      options: [ButtonTheme.DEFAULT, ButtonTheme.ROUNDED],
+    },
+    size: {
+      control: {
+        type: 'radio',
+      },
+      options: [ButtonSize.SMALL, ButtonSize.MEDIUM, ButtonSize.LARGE, ButtonSize.X_LARGE],
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+};
+
+export const Default = args => <Button {...args}>버튼</Button>;

--- a/src/components/atoms/Button/Button.style.js
+++ b/src/components/atoms/Button/Button.style.js
@@ -1,0 +1,82 @@
+import styled, { css } from 'styled-components';
+
+import { ButtonTheme, ButtonSize } from '@components/atoms/Button/index';
+import { COLOR, FONT_SIZE, FONT_WEIGHT } from '@constants';
+
+const themeStyles = css`
+  ${({ theme }) =>
+    theme === ButtonTheme.DEFAULT &&
+    css`
+      border-radius: 7px;
+    `}
+
+  ${({ theme }) =>
+    theme === ButtonTheme.ROUNDED &&
+    css`
+      border-radius: 30px;
+    `}
+  }
+`;
+
+const sizeStyles = css`
+  ${({ size }) =>
+    size === ButtonSize.SMALL &&
+    css`
+      width: 80px;
+      height: 40px;
+      font-size: ${FONT_SIZE.MEDIUM};
+    `}
+
+  ${({ size }) =>
+    size === ButtonSize.MEDIUM &&
+    css`
+      width: 100px;
+      height: 35px;
+      font-size: ${FONT_SIZE.SMALL};
+    `}
+
+  ${({ size }) =>
+    size === ButtonSize.LARGE &&
+    css`
+      width: 150px;
+      height: 80px;
+      font-size: ${FONT_SIZE.LARGE};
+    `}
+
+  ${({ size }) =>
+    size === ButtonSize.X_LARGE &&
+    css`
+      width: 250px;
+      height: 58px;
+      font-size: ${FONT_SIZE.MEDIUM};
+    `}
+  }
+`;
+
+const Button = styled.button`
+  color: ${COLOR.WHITE};
+  font-weight: ${FONT_WEIGHT.BOLD};
+  background-color: ${COLOR.BLUE};
+  transition: all 200ms;
+
+  &:hover {
+    background-color: ${COLOR.DARK_BLUE};
+  }
+
+  &:disabled {
+    background-color: ${COLOR.GREY};
+  }
+
+  span {
+    position: relative;
+    top: -1px;
+  }
+
+  /* 테마 */
+  ${themeStyles}
+
+  /* 크기 */
+  ${sizeStyles}
+`;
+
+export { Button };

--- a/src/components/atoms/Button/index.jsx
+++ b/src/components/atoms/Button/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import * as S from '@components/atoms/Button/Button.style';
+
+export const ButtonTheme = {
+  DEFAULT: 'default',
+  ROUNDED: 'roudned',
+};
+
+export const ButtonSize = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+  X_LARGE: 'x-large',
+};
+
+const Button = ({ onClick, children, theme, size, disabled }) => {
+  const buttonProps = { theme: theme, size: size };
+
+  return (
+    <S.Button type='button' onClick={onClick} disabled={disabled} {...buttonProps}>
+      <span>{children}</span>
+    </S.Button>
+  );
+};
+
+Button.propTypes = {
+  theme: PropTypes.string,
+  size: PropTypes.string,
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+};
+
+Button.defaultProps = {
+  theme: ButtonTheme.DEFAULT,
+  size: ButtonSize.MEDIUM,
+  onClick: () => {},
+  disabled: false,
+};
+
+export default Button;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ReactDOM from 'react-dom/client';
 
 import App from './App';


### PR DESCRIPTION
## 📃 Description

- https://github.com/mina-gwak/fe-vm/issues/2
- `Button` 컴포넌트를 생성했고, 스토리에 타입을 나타내기 위해 `prop-types`를 적용했다.
- `css`를 사용해 `props` 값에 따라 다른 스타일을 적용할 수 있도록 했다.
- 버튼의 스토리를 생성하고, `prop`마다 `control`을 생성해 쉽게 테스트할 수 있도록 했다.

## 📸 Screenshot

<img width="713" alt="스토리 예시" src="https://user-images.githubusercontent.com/62706988/168145115-ccf6a81a-2660-48a6-9e89-490683c95c5a.png">